### PR TITLE
Small fix in script + contributed courses

### DIFF
--- a/_courses/CIT/IN218307/2021SS-endterm.md
+++ b/_courses/CIT/IN218307/2021SS-endterm.md
@@ -1,0 +1,27 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN218307"
+semester: "2021SS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Seminar: Topics of Quantum Computing"
+date: "2021-07-08 00:00:00 +0100"
+
+ects: 5
+hours: 2 # semester hours
+mode: "assessed/continuous assessment"
+lang: "en"
+
+title: "Seminar: Topics of Quantum Computing 2021SS Endterm"
+grades:
+  - { grade: 1.0, people: 7 }
+  - { grade: 1.3, people: 2 }
+  - { grade: 1.7, people: 2 }
+  - { grade: 2.7, people: 1 }
+  - { grade: 5.0, people: 1 }
+  - { grade: 6.0, people: 2 }
+
+---
+
+

--- a/_courses/CIT/IN2211/2021WS-endterm.md
+++ b/_courses/CIT/IN2211/2021WS-endterm.md
@@ -1,0 +1,35 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN2211"
+semester: "2021WS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Auction Theory and Market Design"
+date: "2022-02-02 00:00:00 +0100"
+
+ects: 5
+hours: 4 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Auction Theory and Market Design 2021WS Endterm"
+grades:
+  - { grade: 1.0, people: 7 }
+  - { grade: 1.3, people: 7 }
+  - { grade: 1.7, people: 8 }
+  - { grade: 2.0, people: 4 }
+  - { grade: 2.3, people: 16 }
+  - { grade: 2.7, people: 15 }
+  - { grade: 3.0, people: 23 }
+  - { grade: 3.3, people: 21 }
+  - { grade: 3.7, people: 25 }
+  - { grade: 4.0, people: 18 }
+  - { grade: 4.3, people: 20 }
+  - { grade: 4.7, people: 17 }
+  - { grade: 5.0, people: 23 }
+  - { grade: 6.0, people: 102 }
+
+---
+
+

--- a/_courses/CIT/IN2229/2021WS-endterm.md
+++ b/_courses/CIT/IN2229/2021WS-endterm.md
@@ -1,0 +1,37 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN2229"
+semester: "2021WS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Computational Social Choice"
+date: "2022-03-02 00:00:00 +0100"
+
+ects: 6
+hours: 5 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Computational Social Choice 2021WS Endterm"
+grades:
+  - { grade: 1.0, people: 18 }
+  - { grade: 1.4, people: 7 }
+  - { grade: 1.7, people: 11 }
+  - { grade: 2.0, people: 10 }
+  - { grade: 2.3, people: 1 }
+  - { grade: 2.4, people: 3 }
+  - { grade: 2.7, people: 6 }
+  - { grade: 3.0, people: 7 }
+  - { grade: 3.3, people: 3 }
+  - { grade: 3.4, people: 3 }
+  - { grade: 3.7, people: 6 }
+  - { grade: 4.0, people: 4 }
+  - { grade: 4.3, people: 8 }
+  - { grade: 4.7, people: 7 }
+  - { grade: 5.0, people: 5 }
+  - { grade: 6.0, people: 55 }
+
+---
+
+

--- a/_courses/CIT/IN2345/2021SS-endterm.md
+++ b/_courses/CIT/IN2345/2021SS-endterm.md
@@ -1,0 +1,34 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN2345"
+semester: "2021SS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Algorithms for Uncertainty Quantification"
+date: "2021-07-29 00:00:00 +0100"
+
+ects: 5
+hours: 4 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Algorithms for Uncertainty Quantification 2021SS Endterm"
+grades:
+  - { grade: 1.0, people: 3 }
+  - { grade: 1.3, people: 1 }
+  - { grade: 1.7, people: 4 }
+  - { grade: 2.0, people: 2 }
+  - { grade: 2.3, people: 1 }
+  - { grade: 2.7, people: 1 }
+  - { grade: 3.0, people: 1 }
+  - { grade: 3.3, people: 3 }
+  - { grade: 3.7, people: 3 }
+  - { grade: 4.0, people: 1 }
+  - { grade: 4.7, people: 1 }
+  - { grade: 5.0, people: 5 }
+  - { grade: 6.0, people: 37 }
+
+---
+
+

--- a/_courses/CIT/IN2346/2020WS-endterm.md
+++ b/_courses/CIT/IN2346/2020WS-endterm.md
@@ -1,0 +1,33 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN2346"
+semester: "2020WS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Introduction to Deep Learning"
+date: "2021-02-23 00:00:00 +0100"
+
+ects: 6
+hours: 4 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Introduction to Deep Learning 2020WS Endterm"
+grades:
+  - { grade: 1.0, people: 11 }
+  - { grade: 1.3, people: 7 }
+  - { grade: 1.7, people: 20 }
+  - { grade: 2.0, people: 52 }
+  - { grade: 2.3, people: 52 }
+  - { grade: 2.7, people: 52 }
+  - { grade: 3.0, people: 71 }
+  - { grade: 3.3, people: 66 }
+  - { grade: 3.7, people: 61 }
+  - { grade: 4.0, people: 10 }
+  - { grade: 5.0, people: 116 }
+  - { grade: 6.0, people: 136 }
+
+---
+
+

--- a/_courses/CIT/IN2361/2020WS-endterm.md
+++ b/_courses/CIT/IN2361/2020WS-endterm.md
@@ -1,0 +1,35 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN2361"
+semester: "2020WS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Natural Language Processing"
+date: "2021-02-24 00:00:00 +0100"
+
+ects: 6
+hours: 4 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Natural Language Processing 2020WS Endterm"
+grades:
+  - { grade: 1.0, people: 7 }
+  - { grade: 1.3, people: 4 }
+  - { grade: 1.7, people: 10 }
+  - { grade: 2.0, people: 13 }
+  - { grade: 2.3, people: 18 }
+  - { grade: 2.7, people: 12 }
+  - { grade: 3.0, people: 12 }
+  - { grade: 3.3, people: 12 }
+  - { grade: 3.7, people: 15 }
+  - { grade: 4.0, people: 9 }
+  - { grade: 4.3, people: 5 }
+  - { grade: 4.7, people: 7 }
+  - { grade: 5.0, people: 19 }
+  - { grade: 6.0, people: 157 }
+
+---
+
+

--- a/_courses/CIT/IN2378/2022SS-endterm.md
+++ b/_courses/CIT/IN2378/2022SS-endterm.md
@@ -1,0 +1,32 @@
+---
+layout: course
+
+school: "CIT"
+code: "IN2378"
+semester: "2022SS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Statistical Foundations of Learning"
+date: "2022-08-18 00:00:00 +0100"
+
+ects: 5
+hours: 4 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Statistical Foundations of Learning 2022SS Endterm"
+grades:
+  - { grade: 1.0, people: 4 }
+  - { grade: 1.3, people: 2 }
+  - { grade: 1.7, people: 2 }
+  - { grade: 2.0, people: 2 }
+  - { grade: 2.7, people: 4 }
+  - { grade: 3.3, people: 3 }
+  - { grade: 3.7, people: 2 }
+  - { grade: 4.0, people: 1 }
+  - { grade: 4.3, people: 5 }
+  - { grade: 5.0, people: 2 }
+  - { grade: 6.0, people: 56 }
+
+---
+
+

--- a/_courses/SZ/SZ0453/2022SS-endterm.md
+++ b/_courses/SZ/SZ0453/2022SS-endterm.md
@@ -1,0 +1,24 @@
+---
+layout: course
+
+school: "SZ"
+code: "SZ0453"
+semester: "2022SS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "English - Scientific Presentation and Writing C2"
+date: "2022-07-27 00:00:00 +0100"
+
+ects: 3
+hours: 2 # semester hours
+mode: "written"
+lang: "en"
+
+title: "English - Scientific Presentation and Writing C2 2022SS Endterm"
+grades:
+  - { grade: 1.3, people: 8 }
+  - { grade: 1.7, people: 2 }
+  - { grade: 2.3, people: 3 }
+
+---
+
+

--- a/_courses/SZ/SZ1203/2021SS-endterm.md
+++ b/_courses/SZ/SZ1203/2021SS-endterm.md
@@ -1,0 +1,24 @@
+---
+layout: course
+
+school: "SZ"
+code: "SZ1203"
+semester: "2021SS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Spanish A2.2"
+date: "2021-07-14 00:00:00 +0100"
+
+ects: 3
+hours: 2 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Spanish A2.2 2021SS Endterm"
+grades:
+  - { grade: 1.0, people: 6 }
+  - { grade: 1.3, people: 5 }
+  - { grade: 6.0, people: 1 }
+
+---
+
+

--- a/_courses/SZ/SZ1216/2022SS-endterm.md
+++ b/_courses/SZ/SZ1216/2022SS-endterm.md
@@ -1,0 +1,24 @@
+---
+layout: course
+
+school: "SZ"
+code: "SZ1216"
+semester: "2022SS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Spanish B1.2"
+date: "2022-07-25 00:00:00 +0100"
+
+ects: 3
+hours: 2 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Spanish B1.2 2022SS Endterm"
+grades:
+  - { grade: 1.7, people: 3 }
+  - { grade: 2.0, people: 2 }
+  - { grade: 2.3, people: 1 }
+
+---
+
+

--- a/_courses/SZ/SZ1218/2021WS-endterm.md
+++ b/_courses/SZ/SZ1218/2021WS-endterm.md
@@ -1,0 +1,26 @@
+---
+layout: course
+
+school: "SZ"
+code: "SZ1218"
+semester: "2021WS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Spanish B1.1"
+date: "2022-02-07 00:00:00 +0100"
+
+ects: 3
+hours: 2 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Spanish B1.1 2021WS Endterm"
+grades:
+  - { grade: 1.3, people: 1 }
+  - { grade: 1.7, people: 2 }
+  - { grade: 2.0, people: 2 }
+  - { grade: 2.3, people: 3 }
+  - { grade: 6.0, people: 2 }
+
+---
+
+

--- a/_courses/SZ/SZ1219/2022WS-endterm.md
+++ b/_courses/SZ/SZ1219/2022WS-endterm.md
@@ -1,0 +1,24 @@
+---
+layout: course
+
+school: "SZ"
+code: "SZ1219"
+semester: "2022WS" # refers to the year of the semester start
+exam_type: "endterm"
+name: "Spanish B2.1"
+date: "2023-02-09 00:00:00 +0100"
+
+ects: 3
+hours: 2 # semester hours
+mode: "written"
+lang: "en"
+
+title: "Spanish B2.1 2022WS Endterm"
+grades:
+  - { grade: 1.0, people: 2 }
+  - { grade: 1.3, people: 2 }
+  - { grade: 1.7, people: 2 }
+
+---
+
+

--- a/scripts/course-glob.py
+++ b/scripts/course-glob.py
@@ -303,14 +303,14 @@ def perform_exam(auth, achievement):
   grades = dict()
   for o in res_achieve_grades:
     value = 0.0
-    if 'gradeCommentShortName' in o:
+    if 'gradeCommentShortName' in o or not o['gradeShortName'][0].isdigit():
       # X didn't show up
       # U cheated
       # Q withdrew
       # Z rejected
       # B passed without grade
       # N didn't pass without grade
-      short_name = o['gradeCommentShortName']
+      short_name = o.get('gradeCommentShortName') or o['gradeShortName']
       if short_name == 'X':
         value = 6.0
       elif short_name == 'U':


### PR DESCRIPTION
In the `course-glob.py` I made a small change: I encountered a case where `gradeShortName` was "B", i.e. not parseable as float. Therefore I changed the code to go into the if branch where `gradeCommentShortName` is checked for letters if the first character of `gradeShortName` is not a digit. This shouldn't change the behavior in any previously supported cases.